### PR TITLE
Support separate ZFS boot pool

### DIFF
--- a/pyzfscmds/system/linux.py
+++ b/pyzfscmds/system/linux.py
@@ -7,7 +7,7 @@ def mountpoint_dataset(mountpoint: str):
     return dataset, or None if not found
     """
 
-    target = re.compile(r'^.*\s*' + mountpoint + r'\s*zfs\b')
+    target = re.compile(r'^.*\s+' + mountpoint + r'\s+zfs\b')
 
     with open("/proc/mounts") as f:
         mount = next((ds for ds in f.read().splitlines() if target.search(ds)), None)


### PR DESCRIPTION
While working in a chroot environment where `/mnt/boot` is used for a second system and `/boot` has been mounted **AFTER** `/mnt/boot` (yes, sounds strange but it could happen)

    target = re.compile(r'^.*\s*' + mountpoint + r'\s*zfs\b')

returns the ZFS pool for `/mnt/boot` which is not correct.